### PR TITLE
Relax version requirements of MDAnalysis

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = { text = "Apache-2.0" }
 dependencies = [
     "nomad-lab>=1.3.6.dev1",
     "nomad-schema-plugin-run>=1.0.1",
-    "mdanalysis==2.7.0",
+    "mdanalysis>=2.7.0",
     "scipy>=1.7.1",
     "networkx>=2.6.3",
 ]


### PR DESCRIPTION
Allow installation of `MDAnalysis > 2.7.0` to satisfy new requirements of `nomad-parser-atomistic`