### PR TITLE
Excluding next major update from accepted MDAnalysis versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = { text = "Apache-2.0" }
 dependencies = [
     "nomad-lab>=1.3.6.dev1",
     "nomad-schema-plugin-run>=1.0.1",
-    "mdanalysis>=2.7.0",
+    "mdanalysis>=2.7.0,<3.0.0",
     "scipy>=1.7.1",
     "networkx>=2.6.3",
 ]


### PR DESCRIPTION
With the next major update of MDAnalysis, we can expect breaking changes, so we should exclude it from the versions we accept in the plugin.