### PR TITLE
Update mdanalysis

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = { text = "Apache-2.0" }
 dependencies = [
     "nomad-lab>=1.3.6.dev1",
     "nomad-schema-plugin-run>=1.0.1",
-    "mdanalysis>=2.7.0",
+    "mdanalysis>=2.7.0,<3.0.0",
     "scipy>=1.7.1",
     "networkx>=2.6.3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 requires-python = ">=3.9"
 
 [project.urls]
-homepage = "https://github.com/nomad-coe/nomad-schema-simulation-workflow-plugin"
+homepage = "https://github.com/nomad-coe/nomad-schema-plugin-simulation-workflow"
 
 [tool.uv]
 dev-dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ license = { text = "Apache-2.0" }
 dependencies = [
     "nomad-lab>=1.3.6.dev1",
     "nomad-schema-plugin-run>=1.0.1",
-    "mdanalysis>=2.7.0,<3.0.0",
+    "mdanalysis>=2.8.0,<3.0.0 ; python_full_version >= '3.10'",
+    "mdanalysis<2.8 ; python_full_version < '3.10'",
     "scipy>=1.7.1",
     "networkx>=2.6.3",
 ]


### PR DESCRIPTION
I changed the MDAnalysis dependencies to dynamic settings including `python<3.10`:
```
"mdanalysis>=2.8.0,<3.0.0 ; python_full_version >= '3.10'",
"mdanalysis<2.8 ; python_full_version < '3.10'",
```
Otherwise, `uv run poe setup` fails: 
```
× No solution found when resolving dependencies for split (python_full_version == '3.9.*' and platform_system == 'Windows'):
  ╰─▶ Because the requested Python version (>=3.9) does not satisfy Python>=3.10 and mdanalysis==2.8.0 depends on Python>=3.10, we can conclude that mdanalysis==2.8.0 cannot be used.
      And because only mdanalysis<=2.8.0 is available, we can conclude that mdanalysis>=2.8.0 cannot be used...
```